### PR TITLE
Refactor/database operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 ---
 
-**nginwho** is a lightweight, efficient and extremely fast program offering three main features at its core:
+**nginwho** is a lightweight, efficient and extremely fast program offering:
 
-1. **nginx** log parser: Stores nginx logs into a **sqlite3** database for further analysis and actions
-2. Restore **Cloudflare** original visitor IP: Continuously parses **Cloudflare CIDRs** (`IPv4` and `IPv6`) through their **API**s so that nginx can leverage it to restore the original IP address of visitors
-3. **Block** untrusted requests: Uses **nftables** to block HTTP and HTTPS requests coming from unknown IP addresses
+1. [nginx log parser](#nginx-log-parser): Stores nginx logs into a **sqlite3** database for further analysis and actions
+2. [Restore Cloudflare](#restore-cloudflare-original-visitor-ip) original visitor IP: Continuously parses **Cloudflare CIDRs** (`IPv4` and `IPv6`) through their **API**s so that nginx can leverage it to restore the original IP address of visitors
+3. [Block untrusted](#block-untrusted-requests) requests using **nftables** to prevent HTTP and HTTPS requests coming from unknown IP addresses
+4. [Reporting](#reporting) on gathered data such as top visited URLs through a TUI
 
 Table of contents:
 
@@ -21,8 +22,13 @@ Table of contents:
     - [nginx Log Parser](#nginx-log-parser)
     - [Restore Cloudflare Original Visitor IP](#restore-cloudflare-original-visitor-ip)
     - [Block Untrusted Requests](#block-untrusted-requests)
+    - [Reporting](#reporting)
+    - [Migrating v1 database to v2](#migrating-v1-database-to-v2)
 
 ## Usage
+
+> [!IMPORTANT]
+> If you have been a user since version 1, please check out [this section](#migrating-v1-database-to-v2) to migrate your database scheme to version 2.
 
 1. Download **nginwho** from this URL:
 
@@ -51,16 +57,17 @@ Table of contents:
     # If you want to omit a certain referrer from being logged (replace thegraynode.io with your domain):
     nginwho --logPath:/var/log/nginx/access.log \
             --dbPath:/var/log/nginwho.db \
-            --omit-referrer:thegraynode.io
+            --omitReferrer:thegraynode.io
 
     # If you want to get real IP addresses of the visitors coming from Cloudflare:
     nginwho --logPath:/var/log/nginx/access.log \
             --dbPath:/var/log/nginwho.db \
-            --omit-referrer:thegraynode.io \
-            --show-real-ips:true
+            --showRealIps:true
    ```
 
-4. Optionally, use the [accompanying systemd](https://github.com/pouriyajamshidi/nginwho/blob/master/nginwho.service) to run **nginwho** as a service in the background and for the it to survive system reboots:
+> Please note that you can mix these flags. They operate independently.
+
+1. Optionally, use the [accompanying systemd](https://github.com/pouriyajamshidi/nginwho/blob/master/nginwho.service) to run **nginwho** as a service in the background and for the it to survive system reboots:
 
    ```bash
    sudo cp nginwho.service /etc/systemd/system/nginwho.service
@@ -78,11 +85,18 @@ Here are the available flags:
   --dbPath,               : Path to SQLite database to log reports (default: /var/log/nginwho.db)
   --logPath,              : Path to nginx access logs (default: /var/log/nginx/access.log)
   --interval              : Refresh interval in seconds (default: 10)
-  --omit-referrer         : Omit a specific referrer from being logged (default: none)
-  --analyze-nginx-logs    : Whether to analyze nginx logs or not. (default: true)
-  --show-real-ips         : Show real IP of visitors by getting Cloudflare CIDRs to include in nginx config.
+  --omitReferrer          : Omit a specific referrer from being logged (default: none)
+  --showRealIps           : Show real IP of visitors by getting Cloudflare CIDRs to include in nginx config.
                             Self-updates every six hours (default: false)
-  --block-untrusted-cidrs : Block untrusted IP addresses using nftables. Only allows Cloudflare CIDRs (default: false)
+  --blockUntrustedCidrs   : Block untrusted IP addresses using nftables. Only allows Cloudflare CIDRs (default: false)
+  --processNginxLogs      : Process nginx logs (default: true)
+  --report                : Enter report mode and query the database for statistics
+
+  --migrateV1ToV2Db       : Migrate V1 database to V2 and exit (default: false).
+                            Use with '--v1DbPath' and '--v2DbPath' flags
+  --v1DbPath              : Path and name of the V1 database (e.g: /var/log/nginwho_v1.db)
+  --v2DbPath              : Path and name of the V2 database (e.g: /var/log/nginwho.db)
+
 ```
 
 ## How it works
@@ -91,65 +105,23 @@ Let's see how nginwho works in a somewhat detailed yet short fashion.
 
 ### nginx Log Parser
 
-For the first and default feature, **nginwho** reads `nginx` logs from `/var/log/nginx/access.log` and stores the parsed results in a **sqlite3** database located in `/var/log/nginwho.db` unless overridden by the [available flags](#flags).
+**nginwho** by default reads `nginx` logs from `/var/log/nginx/access.log` and stores the parsed results in a **sqlite3** database located in `/var/log/nginwho.db` unless overridden by the [available flags](#flags).
 
 > [!WARNING]
-> nginwho only supports the default nginx log format for now
-
-The table name inside the `nginwho.db` database is also named `ngiwho` and here is the schema of it:
-
-```text
-sqlite> PRAGMA table_info(nginwho);
-+-----+-------------------+---------+---------+------------+----+
-| cid |       name        |  type   | notnull | dflt_value | pk |
-+-----+-------------------+---------+---------+------------+----+
-| 0   | id                | INTEGER | 0       |            | 1  |
-| 1   | date              | TEXT    | 1       |            | 0  |
-| 2   | remoteIP          | TEXT    | 1       |            | 0  |
-| 3   | httpMethod        | TEXT    | 1       |            | 0  |
-| 4   | requestURI        | TEXT    | 1       |            | 0  |
-| 5   | statusCode        | TEXT    | 1       |            | 0  |
-| 6   | responseSize      | TEXT    | 1       |            | 0  |
-| 7   | referrer          | TEXT    | 1       |            | 0  |
-| 8   | userAgent         | TEXT    | 1       |            | 0  |
-| 9   | nonStandard       | TEXT    | 0       |            | 0  |
-| 10  | remoteUser        | TEXT    | 1       |            | 0  |
-| 11  | authenticatedUser | TEXT    | 1       |            | 0  |
-+-----+-------------------+---------+---------+------------+----+
-```
-
-If you want to see the top 30 visited URIs of your server, then you could:
-
-1. Run `sqlite3`'s shell:
-
-   ```bash
-   sqlite3 --readonly --table /var/log/nginwho.db
-   ```
-
-2. run a **SQL** query like:
-
-   ```sql
-   SELECT requestURI, count(*) as visits
-   FROM nginwho
-   GROUP BY requestURI
-   ORDER BY visits DESC
-   LIMIT 30;
-   ```
-
-This will give you a nice table with your top 30 visited URIs.
+> nginwho only supports the default nginx log format or any application that logs in the same format for now
 
 ### Restore Cloudflare Original Visitor IP
 
-The second feature, `--show-real-ips` flag fetches **Cloudflare CIDRs** (`IPv4` and `IPv6`) every _six hours_ through their **API**s and writes the result to a file located in `/etc/nginx/nginwho`.
+The second feature, `--showRealIps` flag fetches **Cloudflare CIDRs** (`IPv4` and `IPv6`) every _six hours_ through their **API**s and writes the result to a file named `nginwho` located in `/etc/nginx/`.
 
 It is worthwhile to mention that **nginwho** leverages the `etag` field in Cloudflare's API response, so, if the newly fetched `etag` is the same as the current one, the `/etc/nginx/nginwho` file will not be overwritten.
 
 If the `/etc/nginx/nginwho` file has changed or this is a fresh run, **nginwho** schedules the **nginx** service to be soft reloaded (`nginx -s reload`) at 3 AM.
 
 > [!IMPORTANT]
-> The `--show-real-ips` flag requires **root privileges**.
+> The `--showRealIps` flag requires **root privileges**.
 
-For `--show-real-ips` flag to work, you need to alter your nginx configuration add this line:
+For `--showRealIps` flag to work, you need to alter your **nginx** configuration add this line to include the generated configuration inside the `/etc/nginx/nginwho` file:
 
 ```text
 include /etc/nginx/nginwho;
@@ -161,21 +133,41 @@ So that nginx knows how to restore original visitor IP addresses.
 
 The third feature, `--block-untrusted-cidrs` flag periodically gets Cloudflare CIDRs, either through:
 
-1. Cloudflare APIs when used in conjunction with `--show-real-ips` flag
-2. or the `/etc/nginx/nginwho` file when the `--show-real-ips` flag is not specified
+1. Cloudflare APIs when used in conjunction with `--showRealIps` flag
+2. or the `/etc/nginx/nginwho` file when the `--showRealIps` flag is not specified
 
-The fetched CIDRs will be checked against your existing **nftables** rules and if necessary, the required rules will be created and added through _nftables JSON API_.
+The fetched CIDRs will be checked against your existing **nftables** rules and if necessary, the required rules will be created and added through _nftable's JSON API_.
 
 There will be a bunch of tests and pre-checks done before applying any policies. These checks include:
 
-1. Existence of Cloudflare IPv4 CIDRs nftables Set (`Cloudflare_IPv4`)
-1. Existence of Cloudflare IPv6 CIDRs nftables Set (`Cloudflare_IPv6`)
+1. Existence of Cloudflare IPv4 CIDRs nftables _Set_ (`Cloudflare_IPv4`)
+1. Existence of Cloudflare IPv6 CIDRs nftables _Set_ (`Cloudflare_IPv6`)
 1. Existence of nftables `nginwho` chain (`prerouting` hook)
 1. Existence of nftables `input` chain
 1. Existence of **drop** policy inside `nginwho` chain for untrusted IP addresses on port **80** and **443**
 1. Existence of **accept** policy inside `input` chain for trusted IP addresses on port **80** and **443**
 
-**nginwho** only creates the necessary changes for **nftables**, if no changes are required, no action will be taken. For instance, if a CIDR gets added or removed, only that part of **nftables** configuration will be changed and the rest remain unchanged.
+**nginwho** only creates the necessary changes. Otherwise, no actions will be taken. For instance, if a CIDR gets added or removed, only that part of **nftables** configuration will be changed and the rest remain unchanged.
 
 > [!IMPORTANT]
 > Since playing with **nftables** could result in blocking yourself out, **nginwho** requires you to have some basic policies in place, in specific, having an `inet filter` table. If you do not have it, **nginwho** will detect that and shows you how to create one.
+
+### Reporting
+
+Running **nginwho** with the `--report` flag will launch a TUI, providing some options (top visited URLs, top visiting IP addresses, etc.) that you can select and specify how many records to be queried.
+
+```bash
+nginwho --report --dbPath:/var/log/nginwho.db
+```
+
+### Migrating v1 database to v2
+
+Running the command below will first check your database for any errors and, if it detects any, will output what recovery command should be run. If everything is fine, it will read out the data from your source database, convert and write the data to version 2 so that nginwho can continue working as intended.
+
+> Also, please be noted to change the database file names according to your setup.
+
+```bash
+nginwho --migrateV1ToV2:true \
+        --v1DbPath:nginwho_v1.db \
+        --v2DbPath:nginwho.db \
+```

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -10,4 +10,4 @@ bin           = @["nginwho"]
 
 # Dependencies
 
-requires "nim >= 2.0.2"
+requires "nim >= 2.2.0"

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.0.1"
+version       = "2.1."
 author        = "pouriya jamshidi"
 description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and non-Cloudflare CIDRs blocker"
 license       = "MIT"

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.0.0"
+version       = "2.0.1"
 author        = "pouriya jamshidi"
 description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and non-Cloudflare CIDRs blocker"
 license       = "MIT"

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.0"
+version       = "2.0.0"
 author        = "pouriya jamshidi"
 description   = "nginwho is a lightweight and extremely fast nginx log parser that stores the result into a sqlite3 database for further analysis and actions"
 license       = "MIT"

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -2,7 +2,7 @@
 
 version       = "2.0.0"
 author        = "pouriya jamshidi"
-description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and blocks non-Cloudflare CIDRs"
+description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and non-Cloudflare CIDRs blocker"
 license       = "MIT"
 srcDir        = "src"
 bin           = @["nginwho"]

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -2,7 +2,7 @@
 
 version       = "2.0.0"
 author        = "pouriya jamshidi"
-description   = "nginwho is a lightweight and extremely fast nginx log parser that stores the result into a sqlite3 database for further analysis and actions"
+description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and blocks non-Cloudflare CIDRs"
 license       = "MIT"
 srcDir        = "src"
 bin           = @["nginwho"]

--- a/nginwho.nimble
+++ b/nginwho.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.1."
+version       = "2.1.0"
 author        = "pouriya jamshidi"
 description   = "nginwho is a lightweight and extremely fast nginx log parser, Cloudflare origin IP resolver and non-Cloudflare CIDRs blocker"
 license       = "MIT"

--- a/nginwho.service
+++ b/nginwho.service
@@ -6,7 +6,13 @@ After=Network.target
 Type=simple
 RemainAfterExit=yes
 User=root
-ExecStart=/usr/local/bin/nginwho --logPath:/var/log/nginx/access.log --dbPath:/var/log/nginwho.db --interval:30 --showRealIps:true --blockUntrustedCidrs:true
+ExecStart=/usr/local/bin/nginwho \
+    --logPath:/var/log/nginx/access.log \
+    --dbPath:/var/log/nginwho.db \
+    --interval:30 \
+    --processNginxLogs:true \
+    --showRealIps:true \
+    --blockUntrustedCidrs:true
 Restart=on-failure
 RestartSec=5
 

--- a/nginwho.service
+++ b/nginwho.service
@@ -6,7 +6,7 @@ After=Network.target
 Type=simple
 RemainAfterExit=yes
 User=root
-ExecStart=/usr/local/bin/nginwho --logPath:/var/log/nginx/access.log --dbPath:/var/log/nginwho.db --interval:30 --show-real-ips:true --block-untrusted-cidrs:true
+ExecStart=/usr/local/bin/nginwho --logPath:/var/log/nginx/access.log --dbPath:/var/log/nginwho.db --interval:30 --showRealIps:true --blockUntrustedCidrs:true
 Restart=on-failure
 RestartSec=5
 

--- a/src/cloudflare.nim
+++ b/src/cloudflare.nim
@@ -1,60 +1,13 @@
-import std/[asyncdispatch, httpclient, json, strformat, options, strutils, times]
+import std/[asyncdispatch, httpclient, json, strformat, options, strutils]
 
 from os import fileExists
 from logging import info, error, warn, fatal
 
 import consts
-from nginx import reloadNginx
-from nftables import acceptOnly, NftSet
+from nginx import reloadNginxAt, populateReverseProxyFile
+from nftables import acceptOnly
+from types import Cidrs, NftSet
 
-
-type
-  Cidrs = object
-    ipv4: JsonNode
-    ipv6: JsonNode
-    etag: string
-    etagChanged: bool
-
-
-proc reloadNginxAt(hour: int = 3, minute: int = 0) {.async.} =
-  info(fmt"Preparing to soft-reload nginx at {hour}:{minute}")
-
-  while true:
-    let now: DateTime = getTime().local()
-    if now.hour == hour and now.minute == minute:
-      reloadNginx()
-
-    await sleepAsync(ONE_MINUTE)
-
-
-proc populateReverseProxyFile(filePath: string, cidrs: Cidrs): bool =
-  info(fmt"Populating CIDRs file in {filePath}")
-
-  let now: string = getTime().format(DATE_FORMAT)
-
-  if cidrs.etagChanged:
-    try:
-      let file: File = open(filePath, fmWrite)
-      defer: file.close()
-
-      file.write("# Cloudflare ranges\n")
-      file.write("# Last update: ", now, "\n")
-      file.write("# Last etag: ", cidrs.etag, "\n\n")
-      file.write("# IPv4 CIDRs\n")
-
-      for cidr in cidrs.ipv4:
-        file.write(NGINX_SET_REAL_IP_FROM, " ", cidr.getStr(), ";", "\n")
-
-      file.write("\n# IPv6 CIDRs\n")
-
-      for cidr in cidrs.ipv6:
-        file.write(NGINX_SET_REAL_IP_FROM, " ", cidr.getStr(), ";", "\n")
-
-      file.write("\n\n", NGINX_REAL_IP_HEADER, " ", NGINX_CF_REAL_IP_HEADER, "\n")
-      return true
-    except:
-      error(fmt"Could not open {filePath}")
-      return false
 
 
 proc getCloudflareCIDRs(): Option[Cidrs] =
@@ -103,9 +56,6 @@ proc getCurrentEtag(configFile: string = NGINX_CIDR_FILE): string =
 proc fetchAndProcessIPCidrs*(blockUntrustedCidrs: bool = false) {.async.} =
   info("Fetching and processing Cloudflare CIDRs")
 
-  if blockUntrustedCidrs:
-    warn("will block untrusted CIDRs using nftables")
-
   while true:
     let currentEtag: string = getCurrentEtag()
     let cfCIDRs: Option[Cidrs] = getCloudflareCIDRs()
@@ -115,15 +65,15 @@ proc fetchAndProcessIPCidrs*(blockUntrustedCidrs: bool = false) {.async.} =
       let cidrs: Cidrs = cfCIDRs.get()
 
       if blockUntrustedCidrs:
+        warn("will block untrusted CIDRs using nftables")
         acceptOnly(NftSet(ipv4: cidrs.ipv4, ipv6: cidrs.ipv6))
 
       if currentEtag != cidrs.etag:
         if populateReverseProxyFile(NGINX_CIDR_FILE, cidrs):
-          waitFor reloadNginxAt()
+          waitFor reloadNginxAt(3, 0)
       else:
         info(fmt"etag has not changed {currentEtag}")
     of false:
       error("Failed fetching CIDRs")
 
     await sleepAsync(SIX_HOURS)
-

--- a/src/consts.nim
+++ b/src/consts.nim
@@ -1,7 +1,7 @@
 import times
 
 const
-  VERSION*: string = "2.0.0"
+  VERSION*: string = "2.0.1"
 
   DATE_FORMAT*: string = "yyyy-MM-dd HH:mm:ss"
 

--- a/src/consts.nim
+++ b/src/consts.nim
@@ -1,7 +1,7 @@
 import times
 
 const
-  VERSION*: string = "1.0.0"
+  VERSION*: string = "2.0.0"
 
   DATE_FORMAT*: string = "yyyy-MM-dd HH:mm:ss"
 

--- a/src/consts.nim
+++ b/src/consts.nim
@@ -1,7 +1,7 @@
 import times
 
 const
-  VERSION*: string = "2.0.1"
+  VERSION*: string = "2.1.0"
 
   DATE_FORMAT*: string = "yyyy-MM-dd HH:mm:ss"
 

--- a/src/consts.nim
+++ b/src/consts.nim
@@ -28,6 +28,8 @@ const
   NGINX_REAL_IP_HEADER*: string = "real_ip_header"
   NGINX_CF_REAL_IP_HEADER*: string = "CF-Connecting-IP;"
 
+  LOG_NOT_FOUND* = -1
+
   TEMP_NFT_FILE_PATH*: string = "temp/nft_working_output.json"
 
   NFT_CMD*: string = "nftables"

--- a/src/database.nim
+++ b/src/database.nim
@@ -25,10 +25,18 @@ proc createTables*(db: DbConn) =
 
   db.exec(sql"BEGIN")
 
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS date
+          (
+            id INTEGER PRIMARY KEY,
+            date TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
   db.exec(sql"""CREATE TABLE IF NOT EXISTS remoteIP
           (
             id INTEGER PRIMARY KEY,
-            ip TEXT UNIQUE NOT NULL,
+            remoteIP TEXT UNIQUE NOT NULL,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -36,7 +44,7 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS httpMethod
           (
             id INTEGER PRIMARY KEY,
-            method TEXT UNIQUE NOT NULL,
+            httpMethod TEXT UNIQUE NOT NULL,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -44,7 +52,7 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS requestURI
           (
             id INTEGER PRIMARY KEY,
-            uri TEXT UNIQUE NOT NULL,
+            requestURI TEXT UNIQUE NOT NULL,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -52,7 +60,15 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS statusCode
           (
             id INTEGER PRIMARY KEY,
-            code TEXT UNIQUE NOT NULL,
+            statusCode TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS responseSize
+          (
+            id INTEGER PRIMARY KEY,
+            responseSize TEXT UNIQUE NOT NULL,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -60,7 +76,7 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS referrer
           (
             id INTEGER PRIMARY KEY,
-            ref TEXT UNIQUE NOT NULL,
+            referrer TEXT UNIQUE NOT NULL,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -68,7 +84,16 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS userAgent
           (
             id INTEGER PRIMARY KEY,
-            agent TEXT UNIQUE NOT NULL,
+            userAgent TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  # TODO: separate this into its own table
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS nonStandard
+          (
+            id INTEGER PRIMARY KEY,
+            nonStandard TEXT UNIQUE,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -76,7 +101,7 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS remoteUser
           (
             id INTEGER PRIMARY KEY,
-            user TEXT UNIQUE NOT NULL,
+            remoteUser TEXT UNIQUE,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -84,7 +109,7 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS authenticatedUser
           (
             id INTEGER PRIMARY KEY,
-            user TEXT UNIQUE NOT NULL,
+            authenticatedUser TEXT UNIQUE,
             count INTEGER NOT NULL DEFAULT 1
           )"""
   )
@@ -92,23 +117,26 @@ proc createTables*(db: DbConn) =
   db.exec(sql"""CREATE TABLE IF NOT EXISTS nginwho
           (
             id INTEGER PRIMARY KEY,
-            date TEXT NOT NULL,
+            date_id INTEGER NOT NULL,
             remoteIP_id INTEGER NOT NULL,
             httpMethod_id INTEGER NOT NULL,
             requestURI_id INTEGER NOT NULL,
             statusCode_id INTEGER NOT NULL,
-            responseSize INTEGER NOT NULL,
+            responseSize_id INTEGER NOT NULL,
             referrer_id INTEGER NOT NULL,
             userAgent_id INTEGER NOT NULL,
-            nonStandard TEXT,
-            remoteUser_id INTEGER NOT NULL,
-            authenticatedUser_id INTEGER NOT NULL,
+            nonStandard_id INTEGER,
+            remoteUser_id INTEGER,
+            authenticatedUser_id INTEGER,
+            FOREIGN KEY (date_id) REFERENCES date(id),
             FOREIGN KEY (remoteIP_id) REFERENCES remoteIP(id),
             FOREIGN KEY (httpMethod_id) REFERENCES httpMethod(id),
             FOREIGN KEY (requestURI_id) REFERENCES requestURI(id),
             FOREIGN KEY (statusCode_id) REFERENCES statusCode(id),
+            FOREIGN KEY (responseSize_id) REFERENCES responseSize(id),
             FOREIGN KEY (referrer_id) REFERENCES referrer(id),
             FOREIGN KEY (userAgent_id) REFERENCES userAgent(id),
+            FOREIGN KEY (nonStandard_id) REFERENCES nonStandard(id),
             FOREIGN KEY (remoteUser_id) REFERENCES remoteUser(id),
             FOREIGN KEY (authenticatedUser_id) REFERENCES authenticatedUser(id)
           )"""
@@ -122,10 +150,11 @@ proc getOrInsertId(db: DbConn, table, column, value: string): int64 =
   let row = db.getRow(sql("SELECT id, count FROM ? WHERE ? = ?"), table, column, value)
 
   if row[0].len == 0:
-    db.exec(sql("INSERT INTO ? (?, count) VALUES (?, 1)"), table, column, value)
-    let insertedRow = db.getRow(sql("SELECT id, count FROM ? WHERE ? = ?"), table, column, value)
-    let rowId = parseInt(insertedRow[0]).int64
-    return rowId
+    # db.exec(sql("INSERT INTO ? (?, count) VALUES (?, 1)"), table, column, value)
+    # let insertedRow = db.getRow(sql("SELECT id FROM ? WHERE ? = ?"),
+    #     table, column, value)
+    # let rowId = parseInt(insertedRow[0]).int64
+    return 0
 
   let rowId = parseInt(row[0]).int64
   let newCount = parseInt(row[1]) + 1
@@ -141,39 +170,48 @@ proc insertLog*(db: DbConn, logs: var seq[Log]) =
   for log in logs:
 
     let
-      remoteIPId = getOrInsertId(db, "remoteIP", "ip", log.remoteIP)
-      httpMethodId = getOrInsertId(db, "httpMethod", "method", log.httpMethod)
-      requestURIId = getOrInsertId(db, "requestURI", "uri", log.requestURI)
-      statusCodeId = getOrInsertId(db, "statusCode", "code", log.statusCode)
-      referrerId = getOrInsertId(db, "referrer", "ref", log.referrer)
-      userAgentId = getOrInsertId(db, "userAgent", "agent", log.userAgent)
-      remoteUserId = getOrInsertId(db, "remoteUser", "user", log.remoteUser)
+      dateId = getOrInsertId(db, "date", "date", log.date)
+      remoteIPId = getOrInsertId(db, "remoteIP", "remoteIP", log.remoteIP)
+      httpMethodId = getOrInsertId(db, "httpMethod", "httpMethod",
+          log.httpMethod)
+      requestURIId = getOrInsertId(db, "requestURI", "requestURI",
+          log.requestURI)
+      statusCodeId = getOrInsertId(db, "statusCode", "statusCode",
+          log.statusCode)
+      responseSizeId = getOrInsertId(db, "responseSize", "responseSize",
+          $log.responseSize)
+      referrerId = getOrInsertId(db, "referrer", "referrer", log.referrer)
+      userAgentId = getOrInsertId(db, "userAgent", "userAgent", log.userAgent)
+      nonStandardId = getOrInsertId(db, "nonStandard", "nonStandard",
+          log.nonStandard)
+      remoteUserId = getOrInsertId(db, "remoteUser", "remoteUser",
+          log.remoteUser)
       authenticatedUserId = getOrInsertId(db, "authenticatedUser", "user",
           log.authenticatedUser)
 
     db.exec(sql"""INSERT INTO nginwho 
             (
-              date,
+              date_id,
               remoteIP_id,
               httpMethod_id,
               requestURI_id,
               statusCode_id,
-              responseSize,
+              responseSize_id,
               referrer_id,
               userAgent_id,
-              nonStandard,
+              nonStandard_id,
               remoteUser_id,
               authenticatedUser_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            log.date,
+            dateId,
             remoteIPId,
             httpMethodId,
             requestURIId,
             statusCodeId,
-            log.responseSize,
+            responseSizeId,
             referrerId,
             userAgentId,
-            log.nonStandard,
+            nonStandardId,
             remoteUserId,
             authenticatedUserId
     )

--- a/src/database.nim
+++ b/src/database.nim
@@ -1,14 +1,20 @@
 import db_connector/db_sqlite
 from std/strformat import fmt
-from strutils import parseInt
+from std/os import fileExists
+from std/strutils import parseInt, contains
 from logging import info, warn, error
 
-from types import Log
+from types import Log, Logs
+from utils import convertDateFormat
 
-# TODO: Implement a hashing mechanism to make sure we do not write duplicates
-# ensure that we account for both standard and nonStandard logs
+# TODO:
+#  1. Implement a hashing mechanism to make sure we do not write duplicates
+#     ensure that we account for both standard and nonStandard logs
+#  2. create a separate table for `nonStandard`
 
 proc getDbConnection*(dbPath: string): DbConn =
+  info(fmt"Opening Database connection to {dbPath}")
+
   try:
     let connection: DbConn = open(dbPath, "", "", "")
     return connection
@@ -17,10 +23,42 @@ proc getDbConnection*(dbPath: string): DbConn =
     quit(1)
 
 proc closeDbConnection*(db: DbConn) =
+  info("Closing Database connection")
+
   try:
     db.close()
   except db_sqlite.DbError as e:
     warn(fmt"Could not close database: {e.msg}")
+
+proc showData() =
+  discard """
+  SELECT
+    nginwho.id,
+    date.date,
+    remoteIP.remoteIP,
+    httpMethod.httpMethod,
+    requestURI.requestURI,
+    statusCode.statusCode,
+    responseSize.responseSize,
+    referrer.referrer,
+    userAgent.userAgent,
+    nonStandard.nonStandard,
+    remoteUser.remoteUser,
+    authenticatedUser.authenticatedUser
+  FROM nginwho
+  JOIN date ON nginwho.date_id = date.id
+  JOIN remoteIP ON nginwho.remoteIP_id = remoteIP.id
+  JOIN httpMethod ON nginwho.httpMethod_id = httpMethod.id
+  JOIN requestURI ON nginwho.requestURI_id = requestURI.id
+  JOIN statusCode ON nginwho.statusCode_id = statusCode.id
+  JOIN responseSize ON nginwho.responseSize_id = responseSize.id
+  JOIN referrer ON nginwho.referrer_id = referrer.id
+  JOIN userAgent ON nginwho.userAgent_id = userAgent.id
+  JOIN nonStandard ON nginwho.nonStandard_id = nonStandard.id
+  JOIN remoteUser ON nginwho.remoteUser_id = remoteUser.id
+  JOIN authenticatedUser ON nginwho.authenticatedUser_id = authenticatedUser.id
+  ORDER BY nginwho.id ASC
+  """
 
 proc createTables*(db: DbConn) =
   info("Creating database tables")
@@ -32,7 +70,7 @@ proc createTables*(db: DbConn) =
   # CREATE INDEX idx_logs_request_uri_id ON logs (request_uri_id);
   # CREATE INDEX idx_logs_user_agent_id ON logs (user_agent_id);
 
-  db.exec(sql"BEGIN")
+  db.exec(sql"BEGIN TRANSACTION")
 
   db.exec(sql"""CREATE TABLE IF NOT EXISTS date
           (
@@ -159,26 +197,22 @@ proc insertOrUpdateColumn(db: DbConn, table, column, value: string): int64 =
   let row = db.getRow(sql(fmt"SELECT id, count FROM {table} WHERE {column} = ?"), value)
 
   if row[0] == "":
-    info(fmt"Inserting value {value} into column {column} in table {table}")
-
     let insertedRowId = db.insertID(sql(
         fmt"INSERT INTO {table} ({column}, count) VALUES (?, 1)"), value)
 
     return insertedRowId
 
-  info(fmt"Updating value {value} into column {column} in table {table}")
-
   let updatedRowId = parseInt(row[0]).int64
-
   let newCount = parseInt(row[1]) + 1
+
   db.exec(sql(fmt"UPDATE {table} SET count = ? WHERE id = ?"), newCount, updatedRowId)
 
   return updatedRowId
 
 proc insertLog*(db: DbConn, logs: var seq[Log]) =
-  info("Writing data to database")
+  info(fmt"Writing {len(logs)} logs to database")
 
-  db.exec(sql"BEGIN")
+  db.exec(sql"BEGIN TRANSACTION")
 
   let insertQuery = """
     INSERT INTO nginwho 
@@ -196,9 +230,9 @@ proc insertLog*(db: DbConn, logs: var seq[Log]) =
        authenticatedUser_id
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   """
-
   let preparedStmt = db.prepare(insertQuery)
   defer: preparedStmt.finalize()
+
 
   for log in logs:
     let
@@ -221,32 +255,6 @@ proc insertLog*(db: DbConn, logs: var seq[Log]) =
       authenticatedUserId = insertOrUpdateColumn(db, "authenticatedUser",
           "authenticatedUser", log.authenticatedUser)
 
-    # db.exec(sql"""INSERT INTO nginwho
-    #         (
-    #           date_id,
-    #           remoteIP_id,
-    #           httpMethod_id,
-    #           requestURI_id,
-    #           statusCode_id,
-    #           responseSize_id,
-    #           referrer_id,
-    #           userAgent_id,
-    #           nonStandard_id,
-    #           remoteUser_id,
-    #           authenticatedUser_id
-    #         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-    #         dateId,
-    #         remoteIPId,
-    #         httpMethodId,
-    #         requestURIId,
-    #         statusCodeId,
-    #         responseSizeId,
-    #         referrerId,
-    #         userAgentId,
-    #         nonStandardId,
-    #         remoteUserId,
-    #         authenticatedUserId
-    # )
     db.exec(
       preparedStmt,
       dateId,
@@ -264,9 +272,25 @@ proc insertLog*(db: DbConn, logs: var seq[Log]) =
 
   db.exec(sql"COMMIT")
 
-
-proc writeToDatabase*(logs: var seq[Log], db: DbConn) =
+proc insertLogV1*(logs: var seq[Log], db: DbConn) {.deprecated: "use insertLog instead".} =
   info("Writing data to database")
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS nginwho
+          (
+            id                  INTEGER PRIMARY KEY,
+            date                TEXT NOT NULL,
+            remoteIP            TEXT NOT NULL,
+            httpMethod          TEXT NOT NULL,
+            requestURI          TEXT NOT NULL,
+            statusCode          TEXT NOT NULL,
+            responseSize        TEXT NOT NULL,
+            referrer            TEXT NOT NULL,
+            userAgent           TEXT NOT NULL,
+            nonStandard         TEXT,
+            remoteUser          TEXT NOT NULL,
+            authenticatedUser   TEXT NOT NULL
+          )"""
+  )
 
   let lastEntryDate: Row = db.getRow(sql"SELECT date FROM nginwho WHERE TRIM(date) <> '' ORDER BY rowid DESC LIMIT 1;")
   var lastEntryDateValue: string
@@ -276,13 +300,11 @@ proc writeToDatabase*(logs: var seq[Log], db: DbConn) =
   else:
     lastEntryDateValue = lastEntryDate[0]
 
-  #TODO: Expand the conditional check (perhaps on user-agent and URL) to
-  # avoid missing entries on busy servers
   if logs[^1].date == lastEntryDateValue:
     info("Rows are already written to DB")
     return
 
-  db.exec(sql"BEGIN")
+  db.exec(sql"BEGIN TRANSACTION")
 
   for log in logs:
     db.exec(sql"""INSERT INTO nginwho
@@ -312,3 +334,82 @@ proc writeToDatabase*(logs: var seq[Log], db: DbConn) =
     )
 
   db.exec(sql"COMMIT")
+
+proc migrateV1ToV2*(v1DbName, v2DbName: string) =
+  info(fmt"Migrating v1 database at '{v1DbName}' to v2 database at '{v2DbName}'")
+
+  if not fileExists(v1DbName):
+    error(fmt("V1 database does not exist at {v1DbName}"))
+    quit(1)
+
+
+  let v1Db = getDbConnection(v1DbName)
+  let v2Db = getDbConnection(v2DbName)
+
+  defer:
+    closeDbConnection(v1Db)
+    closeDbConnection(v2Db)
+
+  createTables(v2Db)
+
+  let selectStatement = sql"""
+    SELECT date, remoteIP, httpMethod, requestURI, statusCode, responseSize, 
+           referrer, userAgent, remoteUser, authenticatedUser
+    FROM nginwho
+    WHERE date IS NOT NULL AND date != ''
+    LIMIT ? OFFSET ?
+  """
+
+  const migrationBatchSize = 10_000
+
+  var
+    logs: Logs
+    batchCount = 0
+    offset = 0
+    totalProcessedRecords = 0
+
+  while true:
+    info(fmt"Processing records in batches of {migrationBatchSize} and offset {offset}")
+
+    let rows = v1Db.getAllRows(selectStatement, migrationBatchSize, offset)
+    if rows.len == 0:
+      break
+
+    for row in rows:
+      let httpMethod = row[2]
+      if httpMethod.contains("\\") or httpMethod.contains("x") or
+          httpMethod.contains("{"):
+        warn(fmt"Skipping due to bad format: {row}")
+
+      let log = Log(
+        date: convertDateFormat(row[0]),
+        remoteIP: row[1],
+        httpMethod: httpMethod,
+        requestURI: row[3],
+        statusCode: row[4],
+        responseSize: parseInt(row[5]),
+        referrer: row[6],
+        userAgent: row[7],
+        remoteUser: row[8],
+        authenticatedUser: row[9]
+      )
+
+      logs.add(log)
+
+      batchCount += 1
+      if batchCount >= migrationBatchSize:
+        insertLog(v2Db, logs)
+
+        batchCount = 0
+        logs = Logs(@[])
+
+    offset += migrationBatchSize
+    totalProcessedRecords += rows.len
+
+  # if there are leftovers, add them
+  if batchCount > 0:
+    insertLog(v2Db, logs)
+
+  info(fmt"Processed {totalProcessedRecords} records")
+
+  quit(0)

--- a/src/database.nim
+++ b/src/database.nim
@@ -1,5 +1,6 @@
 import db_connector/db_sqlite
 from std/strformat import fmt
+from strutils import parseInt
 from logging import info, warn, error
 
 from types import Log
@@ -22,23 +23,162 @@ proc closeDbConnection*(db: DbConn) =
 proc createTables*(db: DbConn) =
   info("Creating database tables")
 
-  db.exec(sql"""CREATE TABLE IF NOT EXISTS nginwho
+  db.exec(sql"BEGIN")
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS remoteIP
           (
-            id                  INTEGER PRIMARY KEY,
-            date                TEXT NOT NULL,
-            remoteIP            TEXT NOT NULL,
-            httpMethod          TEXT NOT NULL,
-            requestURI          TEXT NOT NULL,
-            statusCode          TEXT NOT NULL,
-            responseSize        TEXT NOT NULL,
-            referrer            TEXT NOT NULL,
-            userAgent           TEXT NOT NULL,
-            nonStandard         TEXT,
-            remoteUser          TEXT NOT NULL,
-            authenticatedUser   TEXT NOT NULL
+            id INTEGER PRIMARY KEY,
+            ip TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
           )"""
   )
 
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS httpMethod
+          (
+            id INTEGER PRIMARY KEY,
+            method TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS requestURI
+          (
+            id INTEGER PRIMARY KEY,
+            uri TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS statusCode
+          (
+            id INTEGER PRIMARY KEY,
+            code TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS referrer
+          (
+            id INTEGER PRIMARY KEY,
+            ref TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS userAgent
+          (
+            id INTEGER PRIMARY KEY,
+            agent TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS remoteUser
+          (
+            id INTEGER PRIMARY KEY,
+            user TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS authenticatedUser
+          (
+            id INTEGER PRIMARY KEY,
+            user TEXT UNIQUE NOT NULL,
+            count INTEGER NOT NULL DEFAULT 1
+          )"""
+  )
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS nginwho
+          (
+            id INTEGER PRIMARY KEY,
+            date TEXT NOT NULL,
+            remoteIP_id INTEGER NOT NULL,
+            httpMethod_id INTEGER NOT NULL,
+            requestURI_id INTEGER NOT NULL,
+            statusCode_id INTEGER NOT NULL,
+            responseSize INTEGER NOT NULL,
+            referrer_id INTEGER NOT NULL,
+            userAgent_id INTEGER NOT NULL,
+            nonStandard TEXT,
+            remoteUser_id INTEGER NOT NULL,
+            authenticatedUser_id INTEGER NOT NULL,
+            FOREIGN KEY (remoteIP_id) REFERENCES remoteIP(id),
+            FOREIGN KEY (httpMethod_id) REFERENCES httpMethod(id),
+            FOREIGN KEY (requestURI_id) REFERENCES requestURI(id),
+            FOREIGN KEY (statusCode_id) REFERENCES statusCode(id),
+            FOREIGN KEY (referrer_id) REFERENCES referrer(id),
+            FOREIGN KEY (userAgent_id) REFERENCES userAgent(id),
+            FOREIGN KEY (remoteUser_id) REFERENCES remoteUser(id),
+            FOREIGN KEY (authenticatedUser_id) REFERENCES authenticatedUser(id)
+          )"""
+  )
+
+  db.exec(sql"COMMIT")
+
+  info("Created database tables")
+
+proc getOrInsertId(db: DbConn, table, column, value: string): int64 =
+  let row = db.getRow(sql("SELECT id, count FROM ? WHERE ? = ?"), table, column, value)
+
+  if row[0].len == 0:
+    db.exec(sql("INSERT INTO ? (?, count) VALUES (?, 1)"), table, column, value)
+    let insertedRow = db.getRow(sql("SELECT id, count FROM ? WHERE ? = ?"), table, column, value)
+    let rowId = parseInt(insertedRow[0]).int64
+    return rowId
+
+  let rowId = parseInt(row[0]).int64
+  let newCount = parseInt(row[1]) + 1
+  db.exec(sql("UPDATE ? SET count = ? WHERE id = ?"), table, newCount, rowId)
+
+  return rowId
+
+proc insertLog*(db: DbConn, logs: var seq[Log]) =
+  info("Writing data to database")
+
+  db.exec(sql"BEGIN")
+
+  for log in logs:
+
+    let
+      remoteIPId = getOrInsertId(db, "remoteIP", "ip", log.remoteIP)
+      httpMethodId = getOrInsertId(db, "httpMethod", "method", log.httpMethod)
+      requestURIId = getOrInsertId(db, "requestURI", "uri", log.requestURI)
+      statusCodeId = getOrInsertId(db, "statusCode", "code", log.statusCode)
+      referrerId = getOrInsertId(db, "referrer", "ref", log.referrer)
+      userAgentId = getOrInsertId(db, "userAgent", "agent", log.userAgent)
+      remoteUserId = getOrInsertId(db, "remoteUser", "user", log.remoteUser)
+      authenticatedUserId = getOrInsertId(db, "authenticatedUser", "user",
+          log.authenticatedUser)
+
+    db.exec(sql"""INSERT INTO nginwho 
+            (
+              date,
+              remoteIP_id,
+              httpMethod_id,
+              requestURI_id,
+              statusCode_id,
+              responseSize,
+              referrer_id,
+              userAgent_id,
+              nonStandard,
+              remoteUser_id,
+              authenticatedUser_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            log.date,
+            remoteIPId,
+            httpMethodId,
+            requestURIId,
+            statusCodeId,
+            log.responseSize,
+            referrerId,
+            userAgentId,
+            log.nonStandard,
+            remoteUserId,
+            authenticatedUserId
+    )
+
+  db.exec(sql"COMMIT")
 
 proc writeToDatabase*(logs: var seq[Log], db: DbConn) =
   info("Writing data to database")

--- a/src/database.nim
+++ b/src/database.nim
@@ -1,0 +1,89 @@
+import db_connector/db_sqlite
+from std/strformat import fmt
+from logging import info, warn, error
+
+from types import Log
+
+
+proc getDbConnection*(dbPath: string): DbConn =
+  try:
+    let connection: DbConn = open(dbPath, "", "", "")
+    return connection
+  except db_sqlite.DbError as e:
+    error(fmt"Could not open or connect to database: {e.msg}")
+    quit(1)
+
+proc closeDbConnection*(db: DbConn) =
+  try:
+    db.close()
+  except db_sqlite.DbError as e:
+    warn(fmt"Could not close database: {e.msg}")
+
+proc createTables*(db: DbConn) =
+  info("Creating database tables")
+
+  db.exec(sql"""CREATE TABLE IF NOT EXISTS nginwho
+          (
+            id                  INTEGER PRIMARY KEY,
+            date                TEXT NOT NULL,
+            remoteIP            TEXT NOT NULL,
+            httpMethod          TEXT NOT NULL,
+            requestURI          TEXT NOT NULL,
+            statusCode          TEXT NOT NULL,
+            responseSize        TEXT NOT NULL,
+            referrer            TEXT NOT NULL,
+            userAgent           TEXT NOT NULL,
+            nonStandard         TEXT,
+            remoteUser          TEXT NOT NULL,
+            authenticatedUser   TEXT NOT NULL
+          )"""
+  )
+
+
+proc writeToDatabase*(logs: var seq[Log], db: DbConn) =
+  info("Writing data to database")
+
+  let lastEntryDate: Row = db.getRow(sql"SELECT date FROM nginwho WHERE TRIM(date) <> '' ORDER BY rowid DESC LIMIT 1;")
+  var lastEntryDateValue: string
+
+  if lastEntryDate[0] == "":
+    info("First time fetching date from DB")
+  else:
+    lastEntryDateValue = lastEntryDate[0]
+
+  #TODO: Expand the conditional check (perhaps on user-agent and URL) to
+  # avoid missing entries on busy servers
+  if logs[^1].date == lastEntryDateValue:
+    info("Rows are already written to DB")
+    return
+
+  db.exec(sql"BEGIN")
+
+  for log in logs:
+    db.exec(sql"""INSERT INTO nginwho
+            (
+              date,
+              remoteIP,
+              httpMethod,
+              requestURI,
+              statusCode,
+              responseSize,
+              referrer,
+              userAgent,
+              nonStandard,
+              remoteUser,
+              authenticatedUser) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+              log.date,
+              log.remoteIP,
+              log.httpMethod,
+              log.requestURI,
+              log.statusCode,
+              log.responseSize,
+              log.referrer,
+              log.userAgent,
+              log.nonStandard,
+              log.remoteUser,
+              log.authenticatedUser
+    )
+
+  db.exec(sql"COMMIT")

--- a/src/database.nim
+++ b/src/database.nim
@@ -250,9 +250,9 @@ proc normalizeNginwhoTable(db: DbConn, logs: seq[Log]) =
   """
 
   for log in logs:
+    # TODO: handle non-defaults
     if log.nonDefault != "":
       continue
-
     db.exec(defaultQuery,
       log.date,
       log.remoteIP,

--- a/src/nftables.nim
+++ b/src/nftables.nim
@@ -2,7 +2,7 @@ import std/[asyncdispatch, os, strformat, json]
 
 from strutils import split, parseInt, isDigit, join, replace, repeat
 from algorithm import sorted
-from json import parseFile
+# from json import parseFile
 from logging import info, error, warn, fatal
 from osproc import execProcess, execCmd
 from net import parseIpAddress, IpAddressFamily

--- a/src/nftables.nim
+++ b/src/nftables.nim
@@ -2,39 +2,13 @@ import std/[asyncdispatch, os, strformat, json]
 
 from strutils import split, parseInt, isDigit, join, replace, repeat
 from algorithm import sorted
-# from json import parseFile
 from logging import info, error, warn, fatal
 from osproc import execProcess, execCmd
 from net import parseIpAddress, IpAddressFamily
+from types import SetType, IPProtocol, NftSet, NftAttrs
 
 import consts
 
-
-type
-  SetType = enum
-    IPv4 = "ipv4_addr"
-    IPv6 = "ipv6_addr"
-
-  IPProtocol = enum
-    IPv4 = "ip"
-    IPv6 = "ip6"
-
-
-type
-  NftSet* = object
-    ipv4*: JsonNode
-    ipv6*: JsonNode
-
-
-type
-  NftAttrs = object
-    withCloudflareV4Set: bool
-    withCloudflareV6Set: bool
-    withNginwhoChain: bool
-    withNginwhoIPv4Policy: bool
-    withNginwhoIPv6Policy: bool
-    withInputChain: bool
-    withInputPolicy: bool
 
 
 proc applyRules(fileName: string = NFT_CIDR_RULES_FILE) =

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -221,8 +221,7 @@ proc runPreChecks(args: Args) =
 
   if args.processNginxLogs:
     ensureNginxLogExists(args.logPath)
-    # TODO: Enable me
-    # ensureNginxExists()
+    ensureNginxExists()
 
   if args.blockUntrustedCidrs:
     ensureNftExists()

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -133,7 +133,12 @@ proc parseLogEntry(logLine: string, omit: string): Log =
       return log
 
     log.httpMethod = matches[5].replace("\"", "")
-    log.requestURI = matches[6].replace("\"", "")
+
+    var requestURI = matches[6].replace("\"", "")
+    if requestURI.endsWith("/"):
+      requestURI = requestURI.strip(chars = {'/'}, trailing = true)
+    log.requestURI = requestURI
+
     log.statusCode = matches[8]
     log.responseSize = matches[9]
 

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -142,12 +142,14 @@ proc parseLogEntry(logLine: string, omit: string): Log =
     log.statusCode = matches[8]
     log.responseSize = matches[9]
 
-    let referrer = matches[10].replace("\"", "")
+    var referrer = matches[10].replace("\"", "")
     if omit != "" and referrer.contains(omit):
       log.referrer = ""
     elif referrer == "-":
       log.referrer = ""
     else:
+      if referrer.endsWith("/"):
+        referrer = referrer.strip(chars = {'/'}, trailing = true)
       log.referrer = referrer
 
     log.userAgent = matches[11..^1].join(" ").replace("\"", "")
@@ -226,7 +228,7 @@ proc runPreChecks(args: Args) =
 
   if args.processNginxLogs:
     ensureNginxLogExists(args.logPath)
-    ensureNginxExists()
+    # ensureNginxExists()
 
   if args.blockUntrustedCidrs:
     ensureNftExists()

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -12,7 +12,7 @@ from types import Args, Log, Logs
 from nginx import ensureNginxExists, ensureNginxLogExists
 from cloudflare import fetchAndProcessIPCidrs
 from nftables import acceptOnly, ensureNftExists
-from database import getDbConnection, closeDbConnection, writeToDatabase, createTables
+from database import getDbConnection, closeDbConnection, writeToDatabase, createTables, insertLog
 
 
 var logger: ConsoleLogger = newConsoleLogger(
@@ -103,7 +103,7 @@ proc parseLogEntry(logLine: string, omit: string): Log =
     log.httpMethod = matches[5].replace("\"", "")
     log.requestURI = matches[6].replace("\"", "")
     log.statusCode = matches[8]
-    log.responseSize = matches[9]
+    log.responseSize = parseInt(matches[9])
 
     let referrer = matches[10].replace("\"", "")
     if omit != "" and referrer.contains(omit):
@@ -140,7 +140,8 @@ proc processAndRecordLogs(args: Args) {.async.} =
       let log = parseLogEntry(line, args.omitReferrer)
       logs.add(log)
 
-    writeToDatabase(logs, db)
+    # writeToDatabase(logs, db)
+    insertLog(db, logs)
 
     await sleepAsync args.interval
 

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -232,6 +232,7 @@ proc main() =
     asyncCheck processAndRecordLogs(args)
 
   if args.showRealIPs:
+    warn("Do not forget to add `include /etc/nginx/nginwho;` in your nginx config file")
     asyncCheck fetchAndProcessIPCidrs(args.blockUntrustedCidrs)
 
   if args.blockUntrustedCidrs and not args.showRealIPs:

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -228,7 +228,7 @@ proc runPreChecks(args: Args) =
 
   if args.processNginxLogs:
     ensureNginxLogExists(args.logPath)
-    # ensureNginxExists()
+    ensureNginxExists()
 
   if args.blockUntrustedCidrs:
     ensureNftExists()

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -12,7 +12,8 @@ from types import Args, Log, Logs
 from nginx import ensureNginxExists, ensureNginxLogExists
 from cloudflare import fetchAndProcessIPCidrs
 from nftables import acceptOnly, ensureNftExists
-from database import getDbConnection, closeDbConnection, writeToDatabase, createTables, insertLog
+from database import getDbConnection, closeDbConnection, writeToDatabase,
+    createTables, insertLog
 
 
 var logger: ConsoleLogger = newConsoleLogger(

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -90,7 +90,7 @@ proc getArgs(): Args =
         if v1DbPath == "" or v2DbPath == "":
           error("Migration needs '--v1DbPath' and '--v2DbPath' flags")
           usage(1)
-        migrateV1ToV2("nginwho_v1.db", "nginwho_v2.db")
+        migrateV1ToV2(v1DbPath, v2DbPath)
 
       of "logPath": args.logPath = p.val
       of "dbPath": args.dbPath = p.val
@@ -166,8 +166,7 @@ proc runPreChecks(args: Args) =
 
   if args.processNginxLogs:
     ensureNginxLogExists(args.logPath)
-    # TODO: Enable me
-    # ensureNginxExists()
+    ensureNginxExists()
 
   if args.blockUntrustedCidrs:
     ensureNftExists()

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -116,8 +116,14 @@ proc parseLogEntry(logLine: string, omit: string): Log =
   if matches.len >= 12:
     log.remoteIP = matches[0]
 
-    log.date = convertDateFormat(matches[3].replace("\"", "").replace("[",
-        "").replace("/", "-"))
+    # Nginx 1.24.0 has decided to write weird and incorrect dates
+    try:
+      log.date = convertDateFormat(matches[3].replace("\"", "").replace("[",
+          "").replace("/", "-"))
+    except Exception as e:
+      error(fmt"Failed parsing date: {e.msg}")
+      log.nonDefault = logLine
+      return log
 
     log.httpMethod = matches[5].replace("\"", "")
     log.requestURI = matches[6].replace("\"", "")

--- a/src/nginwho.nim
+++ b/src/nginwho.nim
@@ -135,7 +135,7 @@ proc parseLogEntry(logLine: string, omit: string): Log =
     log.httpMethod = matches[5].replace("\"", "")
 
     var requestURI = matches[6].replace("\"", "")
-    if requestURI.endsWith("/"):
+    if requestURI.endsWith("/") and len(requestURI) > 1:
       requestURI = requestURI.strip(chars = {'/'}, trailing = true)
     log.requestURI = requestURI
 

--- a/src/nginx.nim
+++ b/src/nginx.nim
@@ -1,9 +1,17 @@
-from os import findExe
+from os import findExe, fileExists
 from osproc import execCmd
+from strformat import fmt
 from logging import info, error, warn, fatal
 
 from consts import NGINX_CMD, NGINX_TEST_CMD, NGINX_RELOAD_CMD
 
+
+proc ensureNginxLogExists*(logPath: string) =
+  info("Ensuring nginx logs exists")
+
+  if not fileExists(logPath):
+    error(fmt"nginx log file not found: {logPath}")
+    quit(1)
 
 proc ensureNginxExists*() =
   info("Ensuring nginx command exists")

--- a/src/nginx.nim
+++ b/src/nginx.nim
@@ -1,16 +1,53 @@
+import std/[asyncdispatch, times]
+from json import JsonNode, getStr, items
 from os import findExe, fileExists
 from osproc import execCmd
 from strformat import fmt
 from logging import info, error, warn, fatal
 
-from consts import NGINX_CMD, NGINX_TEST_CMD, NGINX_RELOAD_CMD
+from types import Cidrs
+from consts import NGINX_CMD, NGINX_TEST_CMD, NGINX_RELOAD_CMD, ONE_MINUTE,
+    DATE_FORMAT, NGINX_SET_REAL_IP_FROM, NGINX_REAL_IP_HEADER, NGINX_CF_REAL_IP_HEADER
+
+
+proc populateReverseProxyFile*(filePath: string, cidrs: Cidrs): bool =
+  info(fmt"Populating CIDRs file in {filePath}")
+
+  let now: string = getTime().format(DATE_FORMAT)
+
+  if cidrs.etagChanged:
+    try:
+      let file: File = open(filePath, fmWrite)
+      defer: file.close()
+
+      file.write("# Cloudflare ranges\n")
+      file.write("# Last update: ", now, "\n")
+      file.write("# Last etag: ", cidrs.etag, "\n\n")
+      file.write("# IPv4 CIDRs\n")
+
+      for cidr in cidrs.ipv4:
+        file.write(NGINX_SET_REAL_IP_FROM, " ", cidr.getStr(), ";", "\n")
+
+      file.write("\n# IPv6 CIDRs\n")
+
+      for cidr in cidrs.ipv6:
+        file.write(NGINX_SET_REAL_IP_FROM, " ", cidr.getStr(), ";", "\n")
+
+      file.write("\n\n", NGINX_REAL_IP_HEADER, " ", NGINX_CF_REAL_IP_HEADER, "\n")
+      return true
+    except:
+      error(fmt"Could not open {filePath}")
+      return false
+
+  info("CIDR tag has not changed")
+  return false
 
 
 proc ensureNginxLogExists*(logPath: string) =
-  info("Ensuring nginx logs exists")
+  info("Ensuring nginx log exists")
 
   if not fileExists(logPath):
-    error(fmt"nginx log file not found: {logPath}")
+    error(fmt"nginx log file not found at: {logPath}")
     quit(1)
 
 proc ensureNginxExists*() =
@@ -28,7 +65,7 @@ proc testNginxConfig(): int =
   return execCmd(command = NGINX_TEST_CMD)
 
 
-proc reloadNginx*() =
+proc reloadNginx() =
   info("Attempting to soft-reload nginx")
 
   let testResult: int = testNginxConfig()
@@ -42,3 +79,15 @@ proc reloadNginx*() =
     error("nginx process reload failed")
   else:
     info("nginx process reloaded successfully")
+
+
+proc reloadNginxAt*(hour: int = 3, minute: int = 0) {.async.} =
+  info(fmt"Preparing to soft-reload nginx at {hour}:{minute}")
+
+  while true:
+    let now: DateTime = getTime().local()
+    if now.hour == hour and now.minute == minute:
+      reloadNginx()
+
+    await sleepAsync(ONE_MINUTE)
+

--- a/src/report.nim
+++ b/src/report.nim
@@ -1,0 +1,141 @@
+import std/tables
+
+from std/terminal import setForegroundColor, resetAttributes, styledWriteLine,
+    styleUnderscore, fgYellow, fgRed, fgGreen, fgBlue
+from logging import info, warn, error
+from std/strformat import fmt
+from std/strutils import parseUInt, repeat
+from std/rdstdin import readLineFromStdin
+from db_connector/db_sqlite import DbConn, Row
+
+from database import getDbConnection, closeDbConnection, getTopIPs,
+    getTopURIs, getTopUnsuccessfulRequests, getTopReferres, getNonDefaults
+
+
+const parenRepeatCount = 80
+
+type OptionProc = proc (db: DbConn, num: uint): seq[Row]
+
+var optionMapping = newTable[string, OptionProc]()
+
+optionMapping["Show top IP addresses"] = getTopIPs
+optionMapping["Show top URIs"] = getTopURIs
+optionMapping["Show top unsuccessful requests"] = getTopUnsuccessfulRequests
+optionMapping["Show top referrers"] = getTopReferres
+optionMapping["Show top non-defaults"] = getNonDefaults
+
+
+
+proc echoSigns(letter: string = "=", count: int = parenRepeatCount) =
+  echo(letter.repeat(count))
+
+
+proc echoNewlines(count: int = 2) =
+  echo("\n".repeat(count))
+
+
+proc showAvailableOptions() =
+  stdout.resetAttributes()
+  setForegroundColor(fgYellow, true)
+
+  echoNewlines()
+  echoSigns()
+
+  var counter = 1
+  for option, _ in optionMapping:
+    stdout.write(counter, ")", " ", option, "\n")
+    counter += 1
+
+  echoSigns()
+  echoNewlines()
+
+  stdout.resetAttributes()
+
+
+proc getUserChoice(): (uint, uint) =
+  stdout.resetAttributes()
+  setForegroundColor(fgBlue, true)
+
+  echoNewlines()
+
+  let option = readLineFromStdin("Select an option number (q to quit): ")
+  let num = readLineFromStdin("Select the number of records to query (q to quit): ")
+  if option == "q" or num == "q":
+    return (0, 0)
+
+  echoNewlines(1)
+
+  try:
+    let parsedOption = parseUInt(option)
+    let parsedNum = parseUInt(num)
+
+    if parsedOption < 1 or parsedNum < 1:
+      error("Option and number should be greater than 0")
+      return getUserChoice()
+
+    if parsedOption > uint(len(optionMapping)):
+      error("Option number is too large... Try again")
+      return getUserChoice()
+
+    return (parsedOption, parsedNum)
+  except ValueError:
+    error("Bad number... Try again")
+    return getUserChoice()
+
+
+proc mapNumToKey(num: uint): OptionProc =
+  var counter = 0
+  for k, v in optionMapping:
+    if num - 1 == uint(counter):
+      return optionMapping[k]
+    counter += 1
+
+
+proc runQueryFunction(option: OptionProc, db: DbConn, num: uint) =
+  stdout.resetAttributes()
+
+  let rows = option(db, num)
+
+  setForegroundColor(fgGreen, true)
+
+  echoNewlines()
+  echoSigns()
+
+  var count = 1
+  for row in rows:
+    stdout.styledWriteLine(fgGreen, fmt"{count}) {row[0]} is seen ",
+        styleUnderscore, row[1], " times")
+    count += 1
+
+  setForegroundColor(fgGreen, true)
+
+  echoSigns()
+  echoNewlines()
+
+  setForegroundColor(fgRed, true)
+  echoSigns("-")
+
+
+proc report*(dbPath: string) =
+  info("Entering report mode")
+
+  let db = getDbConnection(dbPath)
+
+  while true:
+    showAvailableOptions()
+
+    let (optionNumber, num) = getUserChoice()
+
+    if optionNumber == 0 and num == 0:
+      stdout.resetAttributes()
+      break
+
+    let option = mapNumToKey(optionNumber)
+    stdout.resetAttributes()
+
+    runQueryFunction(option, db, num)
+
+  stdout.resetAttributes()
+  info("Exiting")
+  closeDbConnection(db)
+  quit(0)

--- a/src/types.nim
+++ b/src/types.nim
@@ -22,5 +22,8 @@ type
     omitReferrer: string,
     showRealIPs: bool,
     blockUntrustedCidrs: bool,
-    analyzeNginxLogs: bool
+    processNginxLogs: bool,
+    migrateV1ToV2Db: bool,
+    v1DbPath: string,
+    v2DbPath: string,
   ]

--- a/src/types.nim
+++ b/src/types.nim
@@ -4,10 +4,10 @@ type Log* = object
   httpMethod*: string
   requestURI*: string
   statusCode*: string
-  responseSize*: int
+  responseSize*: string
   referrer*: string
   userAgent*: string
-  nonStandard*: string
+  nonDefault*: string
   remoteUser*: string
   authenticatedUser*: string
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -25,6 +25,7 @@ type
     showRealIPs: bool,
     blockUntrustedCidrs: bool,
     processNginxLogs: bool,
+    report: bool,
     migrateV1ToV2Db: bool,
     v1DbPath: string,
     v2DbPath: string,

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,8 +1,6 @@
 type Log* = object
-  remoteIP*: string
-  remoteUser*: string
-  authenticatedUser*: string
   date*: string
+  remoteIP*: string
   httpMethod*: string
   requestURI*: string
   statusCode*: string
@@ -10,6 +8,8 @@ type Log* = object
   referrer*: string
   userAgent*: string
   nonStandard*: string
+  remoteUser*: string
+  authenticatedUser*: string
 
 
 type

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,0 +1,26 @@
+type Log* = object
+  remoteIP*: string
+  remoteUser*: string
+  authenticatedUser*: string
+  date*: string
+  httpMethod*: string
+  requestURI*: string
+  statusCode*: string
+  responseSize*: string
+  referrer*: string
+  userAgent*: string
+  nonStandard*: string
+
+
+type
+  Logs* = seq[Log]
+
+  Args* = tuple[
+    logPath: string,
+    dbPath: string,
+    interval: int,
+    omitReferrer: string,
+    showRealIPs: bool,
+    blockUntrustedCidrs: bool,
+    analyzeNginxLogs: bool
+  ]

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,3 +1,5 @@
+from std/json import JsonNode
+
 type Log* = object
   date*: string
   remoteIP*: string
@@ -27,3 +29,38 @@ type
     v1DbPath: string,
     v2DbPath: string,
   ]
+
+
+type
+  Cidrs* = object
+    ipv4*: JsonNode
+    ipv6*: JsonNode
+    etag*: string
+    etagChanged*: bool
+
+
+type
+  SetType* = enum
+    IPv4 = "ipv4_addr"
+    IPv6 = "ipv6_addr"
+
+  IPProtocol* = enum
+    IPv4 = "ip"
+    IPv6 = "ip6"
+
+
+type
+  NftSet* = object
+    ipv4*: JsonNode
+    ipv6*: JsonNode
+
+
+type
+  NftAttrs* = object
+    withCloudflareV4Set*: bool
+    withCloudflareV6Set*: bool
+    withNginwhoChain*: bool
+    withNginwhoIPv4Policy*: bool
+    withNginwhoIPv6Policy*: bool
+    withInputChain*: bool
+    withInputPolicy*: bool

--- a/src/types.nim
+++ b/src/types.nim
@@ -6,7 +6,7 @@ type Log* = object
   httpMethod*: string
   requestURI*: string
   statusCode*: string
-  responseSize*: string
+  responseSize*: int
   referrer*: string
   userAgent*: string
   nonStandard*: string

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -1,5 +1,17 @@
-from times import parse, Datetime, format
+from std/times import parse, Datetime, format, epochTime
+from std/strutils import formatFloat
+from std/strformat import fmt
 
 proc convertDateFormat*(nginxDate: string): string =
   let parsedDate: DateTime = parse(nginxDate, "d-MMM-yyyy:HH:mm:ss")
   return parsedDate.format("yyyy-MM-dd HH:mm:ss")
+
+
+template benchmark*(benchmarkName: string, code: untyped) =
+  block:
+    let start = epochTime()
+    code
+    let elapsed = epochTime() - start
+    let elapsedStr = elapsed.formatFloat(format = ffDecimal, precision = 3)
+    echo(fmt"Elapsed time: [ {benchmarkName} ] {elapsedStr}s")
+

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -1,0 +1,5 @@
+from times import parse, Datetime, format
+
+proc convertDateFormat*(nginxDate: string): string =
+  let parsedDate: DateTime = parse(nginxDate, "d-MMM-yyyy:HH:mm:ss")
+  return parsedDate.format("yyyy-MM-dd HH:mm:ss")


### PR DESCRIPTION
## Summary for version 2 release

This is a very big and breaking change, fixing and enhancing many of the quirks in version 1.

- implement reporting using `--report` flag
- add v1 to v2 database migration support (uses 1/10th of disk space comparing to the previous method)
- major cleanup of existing code
- remove trailing '/'s from referrer
- remove trailing '/' from URLs
- add a warning for inclusion of nginwho addition to nginx file
- optimize log file handling and minor cleanups
- collect types in one file
- replace types and improve functions separation logic
- implement performant DB log insertion and avoid duplicate log inserts
- fix date parsing bug introduced in Nginx 1.24.0
- re-design database operations logic for inserts
- better handling on log file reads to save CPU cycles
- convert response size to string and rename nonstandard to nondefault
- bump Nim version
- adjust flags based on version 2
- update README